### PR TITLE
Updated .gitignore to include LastFail picture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+#Picture Saves
+LastFail.jpg


### PR DESCRIPTION
Added LastFail picture to .gitignore so that it will not be included as a change in the Git Repo.